### PR TITLE
Remove unused NuGet.Packaging dependency and update branch filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
           context: DeploymentKeys
           filters:
             branches:
-              only: master
+              only: main
             tags:
               ignore: /.*/
       - publish:
@@ -95,6 +95,6 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/

--- a/SemanticRelease.DotNet.csproj
+++ b/SemanticRelease.DotNet.csproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.9.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.14.0" />
     <PackageReference Include="SemanticRelease.Abstractions" Version="1.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description
- Removed the unused `NuGet.Packaging` dependency from the `.csproj` file.
- Updated CircleCI configuration to replace `master` branch filters with `main` for branch consistency.

### Checklist
- [x] All existing and new tests pass.
- [x] Code changes have been reviewed.
- [x] Relevant documentation has been updated (if applicable).