### PR TITLE
chore(ci): simplify CircleCI config, ignore `node_modules` in git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,13 @@ jobs:
           keys:
             - node-deps-{{ checksum "SemanticRelease.DotNet.sln" }}
             - node-deps-
+      - run: mkdir -p artifacts
       - run: |
           npm install --no-save \
             semantic-release \
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
-            @semantic-release/changelog \
             @semantic-release/exec \
-            @semantic-release/git \
             @semantic-release/github
       - run: npx semantic-release
       - persist_to_workspace:
@@ -64,7 +63,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ./artifacts
-      - run: ls -R
       - run:
           name: Validate presence of API Key
           command: 'echo "Key is: ${NugetAuthentication:0:4}****"'

--- a/.gitignore
+++ b/.gitignore
@@ -418,3 +418,4 @@ FodyWeavers.xsd
 *.msp
 
 .idea/
+node_modules/


### PR DESCRIPTION
Removed unused `@semantic-release/git` and `@semantic-release/changelog` dependencies, reduced unnecessary steps, and added `mkdir artifacts`. Updated `.gitignore` to exclude `node_modules` directory. Streamlined configuration for efficiency.